### PR TITLE
Replaced Float with Double

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/richardpiazza/Swift2D.git",
         "state": {
           "branch": null,
-          "revision": "d3aa067d4c9bfa97fb09b67b2b638bc134fae8d7",
-          "version": "1.1.0"
+          "revision": "4df6f74d3e3ad11075ea53fbb13fceda7c60b7b6",
+          "version": "2.0.0"
         }
       },
       {
@@ -41,9 +41,9 @@
         "package": "SwiftSVG",
         "repositoryURL": "https://github.com/richardpiazza/SwiftSVG.git",
         "state": {
-          "branch": "main",
-          "revision": "e44c386a20708a515ddf6fedd0ad1ef3ba79fa13",
-          "version": null
+          "branch": null,
+          "revision": "ef024d61218b044e2aa90dde2469d2e080308e26",
+          "version": "0.9.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/richardpiazza/SwiftSVG.git",
-            .branch("main")
+            from: "0.9.0"
         ),
         .package(
             url: "https://github.com/richardpiazza/SwiftColor.git",

--- a/Sources/Executable/Render.swift
+++ b/Sources/Executable/Render.swift
@@ -31,7 +31,7 @@ struct Render: ParsableCommand {
     var filename: String
     
     @Option(help: "The horizontal and vertical output size.")
-    var size: Float?
+    var size: Double?
     
     mutating func validate() throws {
         guard !filename.isEmpty else {

--- a/Sources/VectorPlus/Path.Command+VectorPlus.swift
+++ b/Sources/VectorPlus/Path.Command+VectorPlus.swift
@@ -135,8 +135,8 @@ extension Path.Command {
     }
 }
 
-private func arcCenter(previousPoint: Point, point: Point, rx: Float, ry: Float, largeArc: Bool, clockwise: Bool, sinφ: Float, cosφ: Float, pxp: Float, pyp: Float) ->
-    (center: Point, angle1: Float, angle2: Float) {
+private func arcCenter(previousPoint: Point, point: Point, rx: Double, ry: Double, largeArc: Bool, clockwise: Bool, sinφ: Double, cosφ: Double, pxp: Double, pyp: Double) ->
+    (center: Point, angle1: Double, angle2: Double) {
         
         let rxsq = pow(rx, 2.0)
         let rysq = pow(ry, 2.0)
@@ -174,8 +174,8 @@ private func arcCenter(previousPoint: Point, point: Point, rx: Float, ry: Float,
         return (Point(x: centerx, y: centery), angle1, angle2)
 }
 
-private func vectorAngle(u: Point, v: Point) -> Float {
-    let sign: Float = ((u.x * v.y - u.y * v.x) < 0.0) ? -1.0 : 1.0
+private func vectorAngle(u: Point, v: Point) -> Double {
+    let sign: Double = ((u.x * v.y - u.y * v.x) < 0.0) ? -1.0 : 1.0
     var dot = u.x * v.x + u.y * v.y
     if dot > 1.0 {
         dot = 1.0
@@ -186,10 +186,10 @@ private func vectorAngle(u: Point, v: Point) -> Float {
     return sign * acos(dot)
 }
 
-private func approximateUnitArc(angle1: Float, angle2: Float) -> (Point, Point, Point) {
+private func approximateUnitArc(angle1: Double, angle2: Double) -> (Point, Point, Point) {
     // If 90 degree circular arc, use a constant
     // as derived from http://spencermortensen.com/articles/bezier-circle
-    let a: Float
+    let a: Double
     switch angle2 {
     case 1.5707963267948966:
         a = 0.551915024494
@@ -207,7 +207,7 @@ private func approximateUnitArc(angle1: Float, angle2: Float) -> (Point, Point, 
     return (Point(x: x1 - y1 * a, y: y1 + x1 * a), Point(x: x2 + y2 * a, y: y2 - x2 * 1), Point(x: x2, y: y2))
 }
 
-private func mapToEllipse(point: Point, rx: Float, ry: Float, sinφ: Float, cosφ: Float, center: Point) -> Point {
+private func mapToEllipse(point: Point, rx: Double, ry: Double, sinφ: Double, cosφ: Double, center: Point) -> Point {
     let x = point.x * rx
     let y = point.y * ry
     let xp = cosφ * x - sinφ * y

--- a/Sources/VectorPlus/VectorPoint.swift
+++ b/Sources/VectorPlus/VectorPoint.swift
@@ -7,7 +7,7 @@ public struct VectorPoint {
         case minus = "-"
     }
     
-    public typealias Offset = (sign: Sign, multiplier: Float)
+    public typealias Offset = (sign: Sign, multiplier: Double)
     
     public var x: Offset
     public var y: Offset

--- a/Tests/VectorPlusTests/Extensions.swift
+++ b/Tests/VectorPlusTests/Extensions.swift
@@ -82,8 +82,8 @@ extension Path.Command: RoughEquatability {
     }
 }
 
-extension Float: RoughEquatability {
-    static func ~~ (lhs: Float, rhs: Float) -> Bool {
+extension Double: RoughEquatability {
+    static func ~~ (lhs: Double, rhs: Double) -> Bool {
         // CGFloat.abs is unavailable on some platforms
         return Swift.abs(lhs - rhs) < 0.001
     }


### PR DESCRIPTION
Replaces instances of Float with Double. This matches the Swift native floating-point type and changes made to **Swift2D** and **SwiftSVG**. Swift 5.5 will also offer native interchangeability between Double and CGFloat (SE-0307)