### PR TITLE
`SVGView` made public.

### DIFF
--- a/Sources/VectorPlus/SwiftUI/SVGView.swift
+++ b/Sources/VectorPlus/SwiftUI/SVGView.swift
@@ -3,12 +3,16 @@ import Swift2D
 import SwiftSVG
 import SwiftUI
 
-struct SVGView: View {
+public struct SVGView: View {
     let svg: SVG
     private var paths: [SwiftSVG.Path] { svg.paths ?? [] }
     private var content: [(Int, SwiftSVG.Path)] { Array(zip(paths.indices, paths)) }
 
-    var body: some View {
+    public init(svg: SVG) {
+        self.svg = svg
+    }
+
+    public var body: some View {
         GeometryReader { geometry in
             ZStack {
                 ForEach(content, id: \.0) { index, path in


### PR DESCRIPTION
I was wondering why `SVGView` could not be found when I imported the library.

It turns out it was not marked as public, which I suppose is just a mishap.

Anyway... here's a PR that makes it public. :)

// @trenskow